### PR TITLE
LongInterval does not catch NumberFormatException

### DIFF
--- a/src/main/java/com/greplin/interval/LongInterval.java
+++ b/src/main/java/com/greplin/interval/LongInterval.java
@@ -105,9 +105,13 @@ public class LongInterval
   public static LongInterval valueOf(final String value) {
     String trimmed = value.trim();
     int middle = trimmed.indexOf('-', 1);
-    long start = Long.parseLong(trimmed.substring(0, middle).trim());
-    long end = Long.parseLong(trimmed.substring(middle + 1).trim());
-    return new LongInterval(start, end);
+    try {
+        long start = Long.parseLong(trimmed.substring(0, middle).trim());
+        long end = Long.parseLong(trimmed.substring(middle + 1).trim());
+        return new LongInterval(start, end);
+    } catch(NumberFormatException e) {
+        throw new NumberFormatException("Passed value does not contain two parsable long values");
+    }
   }
 
 

--- a/src/test/java/com/greplin/interval/LongIntervalTest.java
+++ b/src/test/java/com/greplin/interval/LongIntervalTest.java
@@ -21,6 +21,11 @@ public class LongIntervalTest {
     assertParse("-2--1", -2, -1);
   }
 
+  @Test(expected=NumberFormatException.class)
+  public void testEmptyNumbers() throws Exception {
+    LongInterval result = LongInterval.valueOf("null-null");
+  }
+
   @Test
   public void testEquals() throws Exception {
     Assert.assertEquals(new LongInterval(1, 100), new LongInterval(1, 100));


### PR DESCRIPTION
LongInterval.java calls `java.lang.long.parseLong` without first checking whether the argument parses. This lead to an uncaught `NumberFormateException`: [Oracle Java 7 API specification](http://docs.oracle.com/javase/7/docs/api/java/lang/Long.html#parseLong%28java.lang.String,%20int%29). 

This pull request adds a check and a test for this issue.
