### PR TITLE
NumericIntervalField does not catch NumberFormatException

### DIFF
--- a/src/main/java/com/greplin/interval/NumericIntervalField.java
+++ b/src/main/java/com/greplin/interval/NumericIntervalField.java
@@ -118,9 +118,13 @@ public final class NumericIntervalField extends AbstractField {
   static long[] splitParts(final String rangeString) {
     String trimmed = rangeString.trim();
     int middle = trimmed.indexOf('-', 1);
-    long start = Long.parseLong(trimmed.substring(0, middle).trim());
-    long end = Long.parseLong(trimmed.substring(middle + 1).trim());
-    return new long[]{start, end};
+    try {
+        long start = Long.parseLong(trimmed.substring(0, middle).trim());
+        long end = Long.parseLong(trimmed.substring(middle + 1).trim());
+        return new long[]{start, end};
+    } catch (NumberFormatException e) {
+        throw new NumberFormatException("Passed value does not contain two parsable long values");
+    }
   }
 
   /**

--- a/src/test/java/com/greplin/interval/NumericIntervalFieldTest.java
+++ b/src/test/java/com/greplin/interval/NumericIntervalFieldTest.java
@@ -54,4 +54,9 @@ public class NumericIntervalFieldTest {
 
     Assert.assertArrayEquals(new long[]{-100, 21253456}, NumericIntervalField.splitParts("-100-21253456"));
   }
+
+  @Test (expected=NumberFormatException.class)
+  public void testEmptyNumbers() throws Exception {
+    long[] result = NumericIntervalField.splitParts("null-null");
+  }
 }


### PR DESCRIPTION
NumericIntervalField.java calls `java.lang.long.parseLong` without first
checking whether the argument parses. This 
lead to an uncaught `NumberFormatException`: [Oracle Java 7 API specification](http://docs.oracle.com/javase/7/docs/api/java/lang/Long.html#parseLong%28java.lang.String,%20int%29). 

This pull request adds a check and a test for this issue.
